### PR TITLE
Fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "run-ts": "tsc --build --verbose && cd output && cp .env output && echo ---------------- && node index.js"
   },
   "author": "CombineSoldier14",
-  "license": "ISC",
+  "license": "GPL-3.0-or-later",
   "dependencies": {
     "cowsay": "^1.6.0",
     "discord.js": "^14.15.3",


### PR DESCRIPTION
This pull request includes a change to the `package.json` file to update the project's license.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-R13): Changed the license from "ISC" to "GPL-3.0-or-later".